### PR TITLE
Add AMD GPU support example

### DIFF
--- a/Docker/Docker_ChatSimple/GPU_AMD/docker-compose.yml
+++ b/Docker/Docker_ChatSimple/GPU_AMD/docker-compose.yml
@@ -1,0 +1,44 @@
+version: '3.8'
+
+services:
+
+  #This gives you a ChatGPT style WebUI -> visit it in your browser at http://localhost:8666
+  #It automatically connects to the load balancer and the Ollama services
+  ollama-webui:
+    image: ollamawebui/ollama-webui
+    container_name: simplechatgpu_amd_ollama-webui
+    restart: always
+    networks:
+      - devnet
+    ports:
+      - 8080:8080
+    environment:
+      - 'OLLAMA_BASE_URL=http://localhost:11434'
+      - 'WEBUI_SECRET_KEY='
+
+  #Workers for Ollama services -> these are the services that actually do the work
+  ollamaworker1:
+    container_name: simplechatgpu_amd_Worker1
+    restart: always
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    deploy:
+      resources:
+        limits:
+          cpus: '4.0'
+          memory: 8g
+        reservations:
+          devices:
+            - driver: rocm
+              count: 1
+              capabilities:
+                - gpu
+    environment:
+      - ROCR_VISIBLE_DEVICES=all
+    networks:
+      - devnet
+
+networks:
+  devnet:
+    driver: bridge

--- a/Docker/Docker_ChatSimple/README.MD
+++ b/Docker/Docker_ChatSimple/README.MD
@@ -1,10 +1,24 @@
 #Simple Chat - gives you a chat with AI
 
-
 Use this for now and run the code to donwload the LLAMA3.1 model
 http://localhost:8888/?token=4BByK477-4EVAH-D34DB33F
-
 
 Visit the chat page here
 http://http://localhost:8666/
 
+# Instructions for using the GPU_AMD folder
+
+To use the GPU_AMD folder with AMD GPU support, follow these steps:
+
+1. Navigate to the `Docker/Docker_ChatSimple/GPU_AMD` directory.
+2. Run the following command to start the services:
+   ```
+   docker-compose up
+   ```
+   (You can add `-d` at the end if you want a long-term service that will remain running on your machine)
+
+3. Visit the front-end at `http://localhost:8080`.
+4. Click the settings Icon, Go to Models. Type in a model name like `llama3.1` and hit retrieve.
+5. Wait a bit and you're golden.
+
+The `docker-compose.yml` file in the `GPU_AMD` folder is configured to support AMD GPUs using the `rocm` driver.


### PR DESCRIPTION
Related to #1

Add AMD GPU support with new docker-compose file and update README.

* **Add AMD GPU support:**
  - Create `Docker/Docker_ChatSimple/GPU_AMD/docker-compose.yml` with AMD GPU support configuration.
  - Add `ollama-webui` service configuration.
  - Add `ollamaworker1` service configuration with AMD GPU support using `rocm` driver and `ROCR_VISIBLE_DEVICES` environment variable.

* **Update README:**
  - Add instructions for using the `GPU_AMD` folder.
  - Mention the new `docker-compose.yml` file for AMD GPU support.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/datawx/ollamafarm/pull/2?shareId=bbdddc0d-d35d-4f98-a8aa-cef45beccdb2).